### PR TITLE
added type flag & motivation + changed iot to cert in cbor-iot

### DIFF
--- a/draft-raza-ace-cbor-certificates.md
+++ b/draft-raza-ace-cbor-certificates.md
@@ -208,7 +208,7 @@ After profiling, all duplicated information has been removed, and remaining text
 
 Further performance improvements can be achieved with the use of native CBOR certificates. In this case the signature is calculated over the CBOR encoded structure rather than the ASN.1 encoded structure. This removes entirely the need for ASN.1 and reduces the processing in the authenticating devices.
 
-This solution applies when the devices are only required to authenticate with a set of native CBOR certificate compatible servers, which may become a preferred approach for future deployments. The mapping between X.509 and CBOR certificates enables a migration path between the backwards compatible format and the fully optimized format.
+This solution applies when the devices are only required to authenticate with a set of native CBOR certificate compatible servers, which may become a preferred approach for future deployments. The mapping between X.509 and CBOR certificates enables a migration path between the backwards compatible format and the fully optimized format. This motivates introducing a type flag to indicate if the certificate should be restored to X.509 or kept cbor encoded.
 
 # Security Considerations  {#sec-cons}
 
@@ -238,7 +238,7 @@ This document registers a compression algorithm in the registry entitled "Certif
 +------------------+--------------------------+
 | Algorithm Number | Description              |
 +------------------+--------------------------+
-| TBD              | cbor-iot                 |
+| TBD              | cbor-cert                |
 +------------------+--------------------------+       
 ~~~~~~~~~~~
 
@@ -249,6 +249,7 @@ This document registers a compression algorithm in the registry entitled "Certif
 
 ~~~~~~~~~~~ CDDL
 certificate = [
+  type : uint,
   serial_number : uint,
   issuer : text,
   validity : [notBefore: int, notAfter: int],


### PR DESCRIPTION
The minimal agreed upon updates. 

The motivation for the optional trailing alg. selection field is already present, it seems we missed it: 

"* Signature algorithm. If the signature algorithm is the default it is omitted in the encoding, otherwise encoded as a one byte COSE identifier. This saves 11 or 12 bytes."

