### PR TITLE
Updates to the CBOR profile structure in CDDL

### DIFF
--- a/draft-raza-ace-cbor-certificates.md
+++ b/draft-raza-ace-cbor-certificates.md
@@ -116,7 +116,7 @@ CBOR certificates are defined in terms of RFC 7925 profiled X.509 certificates:
 
 * version. The 'version' field is known (fixed to v3), and is omitted in the CBOR encoding.
 
-* serialNumber. The 'serialNumber' field is encoded as a CBOR unsigned integer.
+* serialNumber. The 'serialNumber' field is encoded as a CBOR byte string.
 
 * signature. The 'signature' field is always the same as the 'signatureAlgorithm' field and always omitted from the CBOR encoding.
 

--- a/draft-raza-ace-cbor-certificates.md
+++ b/draft-raza-ace-cbor-certificates.md
@@ -120,7 +120,7 @@ CBOR certificates are defined in terms of RFC 7925 profiled X.509 certificates:
 
 * signature. The 'signature' field is always the same as the 'signatureAlgorithm' field and always omitted from the CBOR encoding.
 
-* issuer. In the general case, the Distinguished Name is encoded as CBOR map. The value is represented as an array, including the original byte value and the value type used for canonical recomposition. If only CN is present the value can be encoded as a single byte value.
+* issuer. In the general case, the Distinguished Name is encoded as CBOR map. The value is represented as an array, including the original byte value and the value type used for canonical recomposition. If only CN is present the value can be encoded as a single byte or text value.
 
 * validity. The 'notBefore' and 'notAfter' UTCTime fields are encoded as as UnixTime in unsigned integer format.
 


### PR DESCRIPTION
The general requirement for CBOR "compression" profiles is a canonical de-composition and re-composition so that:

* the CBOR data item in motion is as small as (feasible) possible,
* signature validation works on the recomposing side, and
* a wide range of TLS profile certificates can be processed.

The proposal in this PR is intended to be a basis for discussion of the following first batch of topics:

* a self-sustaining consistent CDDL spec,
* different handling of the hierarchical names subject and issuer,
* retaining directoryString types and also AI5,
* retaining potential alg parameters,
* simplified enumeration for mandatory TLS profile extensions, and
* retaining arbitrary extensions.



